### PR TITLE
fixes: FQCN, var naming, and include_tasks deprecation

### DIFF
--- a/tasks/aws-lb.yaml
+++ b/tasks/aws-lb.yaml
@@ -3,21 +3,21 @@
 - name: Load Balancer | AWS | Discovery VPC by Name
   amazon.aws.ec2_vpc_net_info:
     filters:
-      "tag:Name": "{{ target.vpc_name }}"
-  when: target.vpc_name is defined
+      "tag:Name": "{{ lb.vpc_name }}"
+  when: lb.vpc_name is defined
   register: vpc_info
 
 - name: Load Balancer | AWS | Set VPC ID from discovery
-  set_fact:
+  ansible.builtin.set_fact:
     vpc_id: "{{ vpc_info.vpcs[0].vpc_id }}"
   when:
-    - target.vpc_name is defined
+    - lb.vpc_name is defined
     - vpc_info.vpcs|length > 0
 
 - name: Load Balancer | AWS | Set VPC ID from config
-  set_fact:
-    vpc_id: "{{ target.vpc_id }}"
-  when: target.vpc_id is defined
+  ansible.builtin.set_fact:
+    vpc_id: "{{ lb.vpc_id }}"
+  when: lb.vpc_id is defined
 
 - name: Load Balancer | AWS | Discovery subnet by names
   ec2_vpc_subnet_info:
@@ -35,12 +35,12 @@
     fail_msg: "'subnet_ids' is empty. No subnet found with names: '{{ lb.subnets_names }}' on VPC '{{ vpc_id }}'"
 
 - name: Load Balancer | AWS | Reset subnet ID List
-  set_fact:
+  ansible.builtin.set_fact:
     subnet_ids: []
   when: lb.subnets_discovery
 
 - name: Load Balancer | AWS | Mount the subnetIds from discovered subnets
-  set_fact:
+  ansible.builtin.set_fact:
     subnet_ids: "{{ subnet_ids|d([]) + [item] }}"
   with_items: "{{ subnet_facts.results | json_query(rt_query) }}"
   vars:
@@ -82,17 +82,17 @@
   register: rec_out
 
 - name: Load Balancer | AWS | Save config | Name
-  set_fact:
+  ansible.builtin.set_fact:
     cluster_state: "{% set x=cluster_state.loadbalancers.__setitem__(lb.openshift_id+'_name', lb_out.load_balancer_name) %}{{ cluster_state }}"
   when: lb.openshift_id is defined
 
 - name: Load Balancer | AWS | Save config | Provider's DNS record
-  set_fact:
+  ansible.builtin.set_fact:
     cluster_state: "{% set x=cluster_state.loadbalancers.__setitem__(lb.openshift_id+'_dns_provider', lb_out.dns_name) %}{{ cluster_state }}"
   when: lb.openshift_id is defined
 
 - name: Load Balancer | AWS | Set config | Custom DNS record
-  set_fact:
+  ansible.builtin.set_fact:
     cluster_state: "{% set x=cluster_state.loadbalancers.__setitem__(lb.openshift_id+'_dns', lb.register_dns[0].record) %}{{ cluster_state }}"
   when:
     - lb.openshift_id is defined
@@ -100,9 +100,11 @@
     - lb.register_dns | length > 0
 
 - name: Load Balancer | AWS | Show resources created
-  debug:
+  ansible.builtin.debug:
     var: lb_out
+  when: debug|d(false)
 
 - name: Load Balancer | AWS | Show DNS records created
-  debug:
+  ansible.builtin.debug:
     var: rec_out
+  when: debug|d(false)

--- a/tasks/aws-target.yaml
+++ b/tasks/aws-target.yaml
@@ -3,67 +3,69 @@
 - name: Target Group | AWS | Discovery VPC ID
   amazon.aws.ec2_vpc_net_info:
     filters:
-      "tag:Name": "{{ target.vpc_name }}"
-  when: target.vpc_name is defined
+      "tag:Name": "{{ tg.vpc_name }}"
+  when: tg.vpc_name is defined
   register: vpc_info
 
 - name: Target Group | AWS | Show VPC Info
-  debug:
+  ansible.builtin.debug:
     var: vpc_info
+  when: debug|d(false)
 
 - name: Target Group | AWS | Set discovered VPC ID
-  set_fact:
+  ansible.builtin.set_fact:
     vpc_id: "{{ vpc_info.vpcs[0].vpc_id }}"
   when:
-    - target.vpc_name is defined
+    - tg.vpc_name is defined
     - vpc_info.vpcs|length > 0
 
 - name: Target Group | AWS | Set VPC ID from config
-  set_fact:
-    vpc_id: "{{ target.vpc_id }}"
-  when: target.vpc_id is defined
+  ansible.builtin.set_fact:
+    vpc_id: "{{ tg.vpc_id }}"
+  when: tg.vpc_id is defined
 
-- name: Target Group | AWS | Create
+- name: Target Group | AWS | Create {{ tg.name }}
   community.aws.elb_target_group:
     state: present
-    region: "{{ target.region | d(omit) }}"
-    name: "{{ target.name }}"
+    region: "{{ tg.region | d(omit) }}"
+    name: "{{ tg.name }}"
     vpc_id: "{{ vpc_id }}"
-    tags: "{{ target.tags | d(omit) }}"
-    purge_tags: "{{ target.purge_tags | d('no') }}"
-    protocol: "{{ target.protocol }}"
-    port: "{{ target.port }}"
+    tags: "{{ tg.tags | d(omit) }}"
+    purge_tags: "{{ tg.purge_tags | d('no') }}"
+    protocol: "{{ tg.protocol }}"
+    port: "{{ tg.port }}"
     # Health Check
-    health_check_protocol: "{{ target.health_check_protocol }}"
-    health_check_path: "{{ target.health_check_path | d(omit) }}"
-    health_check_port: "{{ target.health_check_port | d(omit) }}"
-    successful_response_codes: "{{ target.successful_response_codes | d(omit) }}"
-    health_check_interval: "{{ target.health_check_interval | d(omit) }}"
-    health_check_timeout: "{{ target.health_check_timeout |d(omit) }}"
-    healthy_threshold_count: "{{ target.healthy_threshold_count | d(omit) }}"
-    unhealthy_threshold_count: "{{ target.unhealthy_threshold_count | d(omit) }}"
+    health_check_protocol: "{{ tg.health_check_protocol }}"
+    health_check_path: "{{ tg.health_check_path | d(omit) }}"
+    health_check_port: "{{ tg.health_check_port | d(omit) }}"
+    successful_response_codes: "{{ tg.successful_response_codes | d(omit) }}"
+    health_check_interval: "{{ tg.health_check_interval | d(omit) }}"
+    health_check_timeout: "{{ tg.health_check_timeout |d(omit) }}"
+    healthy_threshold_count: "{{ tg.healthy_threshold_count | d(omit) }}"
+    unhealthy_threshold_count: "{{ tg.unhealthy_threshold_count | d(omit) }}"
     # Targets
-    target_type: "{{ target.target_type | d(omit) }}"
-    modify_targets: "{{ target.modify_targets | d(omit) }}"
-    tagets: "{{ target.tagets | d(omit) }}"
+    target_type: "{{ tg.target_type | d(omit) }}"
+    modify_targets: "{{ tg.modify_targets | d(omit) }}"
+    tagets: "{{ tg.tagets | d(omit) }}"
     # Config
-    stickiness_enabled: "{{ target.stickiness_enabled | d(omit) }}"
-    stickiness_app_cookie_duration: "{{ target.stickiness_app_cookie_duration | d(omit) }}"
-    stickiness_app_cookie_name: "{{ target.stickiness_app_cookie_name | d(omit) }}"
-    stickiness_lb_cookie_duration: "{{ target.stickiness_lb_cookie_duration | d(omit) }}"
-    stickiness_type: "{{ target.stickiness_type | d(omit) }}"
-    proxy_protocol_v2_enabled: "{{ target.proxy_protocol_v2_enabled | d(omit) }}"
-    preserve_client_ip_enabled: "{{ target.preserve_client_ip_enabled | d(omit) }}"
-    deregistration_delay_timeout: "{{ target.deregistration_delay_timeout | d(omit) }}"
+    stickiness_enabled: "{{ tg.stickiness_enabled | d(omit) }}"
+    stickiness_app_cookie_duration: "{{ tg.stickiness_app_cookie_duration | d(omit) }}"
+    stickiness_app_cookie_name: "{{ tg.stickiness_app_cookie_name | d(omit) }}"
+    stickiness_lb_cookie_duration: "{{ tg.stickiness_lb_cookie_duration | d(omit) }}"
+    stickiness_type: "{{ tg.stickiness_type | d(omit) }}"
+    proxy_protocol_v2_enabled: "{{ tg.proxy_protocol_v2_enabled | d(omit) }}"
+    preserve_client_ip_enabled: "{{ tg.preserve_client_ip_enabled | d(omit) }}"
+    deregistration_delay_timeout: "{{ tg.deregistration_delay_timeout | d(omit) }}"
   register: tg_out
 
 - name: Target Group | AWS | Show resource created
-  debug:
+  ansible.builtin.debug:
     var: tg_out
+  when: debug|d(false)
 
 - name: Target Group | AWS | Discovery and register EC2 targets
-  include: aws-tg-register-ec2.yaml
-  with_items: "{{ target.register_ec2 | d([]) }}"
-  when: target.register_ec2 is defined
+  ansible.builtin.include_tasks: aws-tg-register-ec2.yaml
+  with_items: "{{ tg.register_ec2 | d([]) }}"
+  when: tg.register_ec2 is defined
   loop_control:
     loop_var: machine

--- a/tasks/aws-tg-register-ec2.yaml
+++ b/tasks/aws-tg-register-ec2.yaml
@@ -1,30 +1,31 @@
 ---
 
 - name: Target Group | AWS | Register EC2 | machine spec
-  debug:
+  ansible.builtin.debug:
     var: machine
 
 - name: Target Group | AWS | Register EC2 | Filter target machines
-  ec2_instance_info:
+  amazon.aws.ec2_instance_info:
     filters: "{{ machine.filters }}"
   register: ec2_out
 
 - name: Target Group | AWS | Register EC2 | ec2 filter spec
-  debug:
+  ansible.builtin.debug:
     var: ec2_out
+  when: debug|d(false)
 
 - name: Target Group | AWS | Register EC2 | ec2 filter check
-  debug:
+  ansible.builtin.debug:
     msg: "The filters provided did not returned any instance. Fix it and try again. Filter={{ machine.filters }}"
   failed_when: ec2_out.instances | length == 0
 
 - name: Target Group | AWS | Register EC2 | Extract instance IP
-  set_fact:
+  ansible.builtin.set_fact:
     machine_target_id: "{{ ec2_out.instances[0].private_ip_address }}"
   when: machine.resource_type == 'ip'
 
 - name: Target Group | AWS | Register EC2 | Extract instance ID
-  set_fact:
+  ansible.builtin.set_fact:
     machine_target_id: "{{ ec2_out.instances[0].instance_id }}"
   when: machine.resource_type == 'instanceId'
 

--- a/tasks/do-lb.yaml
+++ b/tasks/do-lb.yaml
@@ -75,7 +75,7 @@
   when: lb_ip | length > 0
 
 - name: Load Balancer | DO | Callback register resources
-  include: "do-lb-register-{{ res.service }}.yaml"
+  include_tasks: "do-lb-register-{{ res.service }}.yaml"
   with_items: "{{ lb.register_resources | d([]) }}"
   loop_control:
     loop_var: res

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,13 +1,13 @@
 ---
 
 - name: Setup Load Balancer Targets
-  include: "{{ target.provider }}-target.yaml"
+  ansible.builtin.include_tasks: "{{ tg.provider }}-target.yaml"
   with_items: "{{ cloud_loadbalancer_targets | d([]) }}"
   loop_control:
-    loop_var: target
+    loop_var: tg
 
 - name: Setup Load Balancers
-  include: "{{ lb.provider }}-lb.yaml"
+  ansible.builtin.include_tasks: "{{ lb.provider }}-lb.yaml"
   with_items: "{{ cloud_loadbalancers | d([]) }}"
   loop_control:
     loop_var: lb


### PR DESCRIPTION
Fixes:
- add FQCN for build-in and AWS modules
- replace deprecated include to include_tasks
- replace `target` var to avoid conflict with upper playbooks used on okd-installer

Tracking:
- https://github.com/mtulio/ansible-collection-okd-installer/pull/10
